### PR TITLE
[Backport 2.19.x] [GEOS-11196] NPE in VectorDownload if ROI not defined

### DIFF
--- a/src/extension/wps-download/src/main/java/org/geoserver/wps/gs/download/VectorDownload.java
+++ b/src/extension/wps-download/src/main/java/org/geoserver/wps/gs/download/VectorDownload.java
@@ -168,7 +168,9 @@ class VectorDownload {
         // do we need to reproject?
         SimpleFeatureCollection reprojectedFeatures;
         if (targetCRS != null && !CRS.equalsIgnoreMetadata(nativeCRS, targetCRS)) {
-            roiManager.useTargetCRS(targetCRS);
+            if (hasROI) {
+                roiManager.useTargetCRS(targetCRS);
+            }
             // testing reprojection...
             final MathTransform targetTX = CRS.findMathTransform(nativeCRS, targetCRS, true);
             if (!targetTX.isIdentity()) {


### PR DESCRIPTION
pr_rerun backport-7263-to-2.19.x to 2.19.x