### PR TITLE
Bump org.springframework:spring-context from 3.2.5.RELEASE to 5.2.21.RELEASE in /src/community/jms-cluster/activemqBroker

### DIFF
--- a/src/community/jms-cluster/activemqBroker/pom.xml
+++ b/src/community/jms-cluster/activemqBroker/pom.xml
@@ -17,7 +17,7 @@
 
   <properties>
     <postgres.version>8.3-603.jdbc4</postgres.version>
-    <spring.version>3.2.5.RELEASE</spring.version>
+    <spring.version>5.2.21.RELEASE</spring.version>
 
   </properties>
 


### PR DESCRIPTION
pr_rerun dependabot/maven/src/community/jms-cluster/activemqBroker/org.springframework-spring-context-5.2.21.RELEASE to main